### PR TITLE
Fix spaces in measurement name or tags

### DIFF
--- a/influxdb-client/Series.m
+++ b/influxdb-client/Series.m
@@ -15,7 +15,13 @@ classdef Series < handle
         
         % Add a tag
         function obj = tag(obj, key, value)
-            obj.Tags{end + 1} = [key '=' value];
+            if isnumeric(value) || islogical(value)
+                obj.Tags{end + 1} = [Series.safeKey(key) '=' value];
+            elseif ischar(value)
+                obj.Tags{end + 1} = [Series.safeKey(key) '=' Series.safeKey(value)];
+            else
+                error('unsupported tag type');
+            end
         end
         
         % Add multiple tags at once
@@ -99,14 +105,15 @@ classdef Series < handle
             end
             
             % Create a line for each sample
-            prefix = strjoin([{obj.Name}, obj.Tags], ',');
-            prefix = [strrep(prefix,' ','\ ') ' '];
+            measurement = Series.safeMeasurement(obj.Name);
+            prefix = [strjoin([{measurement}, obj.Tags], ',') ' '];
+            
             builder = '';
             for i = 1:field_lengths
                 values = '';
                 for f = 1:length(obj.Fields)
                     field = obj.Fields{f};
-                    name = field.key;
+                    name = Series.safeKey(field.key);
                     value = field.value;
                     if iscell(value)
                         str = obj.fieldFmt(name, value{i});
@@ -143,12 +150,26 @@ classdef Series < handle
             elseif isinteger(value)
                 str = sprintf('%s=%ii', key, value);
             elseif ischar(value)
-                str = [key '="' value '"'];
+                str = [key '="' Series.safeValue(value) '"'];
             elseif islogical(value)
                 str = [key '=' iif(value, 'true', 'false')];
             else
                 error('unsupported value type');
             end
+        end
+        
+        % The following functions escape special characters according to:
+        % https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_reference/#special-characters
+        function safe = safeValue(value)
+            safe = regexprep(value, '["\\]', '\\$0');
+        end
+        
+        function safe = safeKey(key)
+            safe = regexprep(key, '[,= ]', '\\$0');
+        end
+        
+        function safe = safeMeasurement(name)
+            safe = regexprep(name, '[, ]', '\\$0');
         end
     end
     

--- a/influxdb-client/Series.m
+++ b/influxdb-client/Series.m
@@ -99,7 +99,8 @@ classdef Series < handle
             end
             
             % Create a line for each sample
-            prefix = [strjoin([{obj.Name}, obj.Tags], ','), ' '];
+            prefix = strjoin([{obj.Name}, obj.Tags], ',');
+            prefix = [strrep(prefix,' ','\ ') ' '];
             builder = '';
             for i = 1:field_lengths
                 values = '';

--- a/tests/SeriesTest.m
+++ b/tests/SeriesTest.m
@@ -308,6 +308,31 @@ classdef SeriesTest < matlab.unittest.TestCase
                 'weather temperature=-3.5,wind_direction="west" 1529933581618'];
             test.verifyEqual(s.toLine(), exp);
         end
+        
+        function measurements_with_spaces_and_commas(test)
+            s = Series('Hello, world!') ...
+                .fields('value', 42);
+
+            expected = 'Hello\,\ world! value=42';
+            test.verifyEqual(s.toLine(), expected);
+        end
+        
+        function tags_with_commas_spaces_and_equals(test)
+            s = Series('Series_A') ...
+                .tags('Annoying, tag = annoying', 'comma="evil", am i right?') ...
+                .fields('value', 42);
+
+            expected = 'Series_A,Annoying\,\ tag\ \=\ annoying=comma\="evil"\,\ am\ i\ right? value=42';
+            test.verifyEqual(s.toLine(), expected);
+        end
+        
+        function fields_with_commas_equals_spaces_quotes_and_slashes(test)
+            s = Series('JSON') ...
+                .fields('strange, json=string', '{"w": "\/\/"}');
+
+            expected = 'JSON strange\,\ json\=string="{\"w\": \"\\/\\/\"}"';
+            test.verifyEqual(s.toLine(), expected);
+        end
     end
     
 end


### PR DESCRIPTION
Escaping spaces in tags or measurement name allows using spaces in them.