### PR TITLE
Fix support of multiple queries in a single request

### DIFF
--- a/influxdb-client/InfluxDB.m
+++ b/influxdb-client/InfluxDB.m
@@ -62,10 +62,14 @@ classdef InfluxDB < handle
             else
                 TimeUtils.validateEpoch(epoch);
             end
-            url = [obj.Url '/query'];
+            if iscell(query)
+                query = strjoin(query, ';');
+            end
+            params = {['db=' database], ['epoch=' epoch], ['q=' query]};
+            url = [obj.Url '/query?' strjoin(params, '&')];
             opts = weboptions('Timeout', obj.ReadTimeout, ...
                 'Username', obj.User, 'Password', obj.Password);
-            response = webread(url, 'db', database, 'epoch', epoch, 'q', query, opts);
+            response = webread(url, opts);
             result = QueryResult.from(response, epoch);
         end
         


### PR DESCRIPTION
At some point the support for sending multiple queries in a single request broke due to an issue with encoding the `;` character that separates queries in the URL. See issue #10.

This PR applies the solution suggested by @b00m18: using another variant of `webread` that encodes the query separator as InfluxDB expects it.